### PR TITLE
refactor(habitats): Streamline image path handling in habitat services

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,8 +105,8 @@ async function bootstrap() {
   console.log('Global prefix /api set');
 
   // Configuration des fichiers statiques
-  app.useStaticAssets(join(process.cwd(), 'uploads'), {
-    prefix: '/api/uploads',
+  app.useStaticAssets(join(__dirname, '..', 'uploads'), {
+    prefix: '/api/uploads/',
   });
 
   // Configuration pour servir les fichiers statiques du dossier public

--- a/src/modules/dashboard/admin-dashboard/habitat-management/controllers/habitat.controller.ts
+++ b/src/modules/dashboard/admin-dashboard/habitat-management/controllers/habitat.controller.ts
@@ -59,9 +59,8 @@ export class HabitatController {
     @UploadedFile() images: Express.Multer.File,
   ): Promise<Habitat> {
     if (images) {
-      habitatData.images = `uploads/habitats/${images.filename}`;
+      habitatData.images = images.filename;
     } else {
-      console.error('Le champ "images" est requis.');
       throw new BadRequestException('Le champ "images" est requis.');
     }
     return this.habitatService.createHabitat(habitatData, 'admin');

--- a/src/modules/dashboard/admin-dashboard/habitat-management/services/habitat.service.ts
+++ b/src/modules/dashboard/admin-dashboard/habitat-management/services/habitat.service.ts
@@ -166,7 +166,7 @@ export class HabitatService {
       id_habitat: row.id_habitat,
       name: row.name,
       description: row.description,
-      images: row.images,
+      images: row.images ? row.images.replace('uploads/habitats/', '') : null,
       created_at: row.created_at,
       updated_at: row.updated_at,
     };

--- a/src/modules/habitats-zoo/services/habitats.service.ts
+++ b/src/modules/habitats-zoo/services/habitats.service.ts
@@ -78,7 +78,7 @@ export class HabitatsService {
       name: row.name,
       description: row.description,
       images: row.images
-        ? `${baseUrl}/api/uploads/habitats/${row.images.split('/').pop()}`
+        ? `${baseUrl}/api/uploads/habitats/${row.images}`
         : null,
       created_at: row.created_at,
       updated_at: row.updated_at,


### PR DESCRIPTION
- Updated HabitatController to directly assign the uploaded image filename, removing the static path prefix.
- Refactored HabitatService to clean image paths by removing the 'uploads/habitats/' prefix when retrieving habitat data.
- Adjusted HabitatsService to format image URLs correctly, ensuring they point to the correct API upload path.