### PR TITLE
Update Dockerfile to create upload directories with enhanced permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,16 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY package*.json ./
 
 # Création des répertoires avec les bonnes permissions
+USER root
+
 RUN mkdir -p /app/dist/modules/mail/templates && \
     mkdir -p /app/uploads/animals && \
     mkdir -p /app/uploads/habitats && \
     mkdir -p /app/uploads/services && \
+    # Utiliser l'utilisateur node existant (UID 1000)
     chown -R node:node /app && \
-    chmod -R 755 /app
+    chmod -R 755 /app && \
+    chmod -R 777 /app/uploads
 
 # Définir l'utilisateur node comme utilisateur par défaut
 USER node


### PR DESCRIPTION
- Added creation of upload directories for animals, habitats, and services.
- Set permissions to 777 for the uploads directory to ensure full access.
- Maintained ownership for the /app directory under the 'node' user for security.
- Adjusted user context to root during directory creation for proper permission settings.