### PR TITLE
Update habitat image handling to include full upload path

### DIFF
--- a/src/modules/dashboard/admin-dashboard/habitat-management/controllers/habitat.controller.ts
+++ b/src/modules/dashboard/admin-dashboard/habitat-management/controllers/habitat.controller.ts
@@ -87,7 +87,7 @@ export class HabitatController {
     console.log('Données habitat reçues:', habitatData);
 
     if (images) {
-      habitatData.images = images.filename;
+      habitatData.images = `uploads/habitats/${images.filename}`;
     } else if (habitatData.images === '0' || !habitatData.images) {
       delete habitatData.images;
     }


### PR DESCRIPTION
- Modified the HabitatController to prepend the upload path to the image filename when saving habitat data.
- Ensured that images are deleted from habitatData if not provided or set to '0', maintaining data integrity.