### PR TITLE
fix: update template path for mail module to use distribution directory

### DIFF
--- a/src/modules/mail/mail.module.ts
+++ b/src/modules/mail/mail.module.ts
@@ -32,7 +32,7 @@ dotenv.config();
     {
       provide: 'TEMPLATE_DIR',
       useFactory: () => {
-        const templatePath = join(process.cwd(), 'src/modules/mail/templates');
+        const templatePath = join(process.cwd(), 'dist/modules/mail/templates');
         console.log('📧 Dossier des templates configuré:', templatePath);
         return templatePath;
       },


### PR DESCRIPTION
- Changed the template directory path in mail.module.ts from 'src/modules/mail/templates' to 'dist/modules/mail/templates' to ensure correct loading of email templates in the production environment.