### PR TITLE
fix: update user ID reference in habitat comment controller

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
@@ -49,7 +49,7 @@ export class HabitatCommentController {
   ): Promise<HabitatComment> {
     return this.habitatCommentService.createHabitatComment(
       habitatCommentData,
-      req.user.id,
+      req.user.sub,
     );
   }
 


### PR DESCRIPTION
- Changed the user ID reference from req.user.id to req.user.sub to align with updated authentication practices.
- Ensured consistency in user identification across the habitat comment creation process.