### PR TITLE
fix: update habitat comment controller route to include API prefix

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
@@ -16,7 +16,7 @@ import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { HabitatComment } from '../models/habitat-comment.model';
 import { HabitatCommentService } from '../services/habitat-comment.service';
 
-@Controller('veterinary/habitat-comments')
+@Controller('api/veterinary/habitat-comments')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class HabitatCommentController {
   constructor(private readonly habitatCommentService: HabitatCommentService) {}


### PR DESCRIPTION
- Changed the controller route from 'veterinary/habitat-comments' to 'api/veterinary/habitat-comments' to standardize API endpoint structure.
- This update aligns with best practices for API versioning and organization.