### PR TITLE
fix: update user ID reference in habitat comment controller to align …

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
@@ -85,7 +85,7 @@ export class HabitatCommentController {
     @Request() req,
   ): Promise<HabitatComment> {
     const commentId = id.toString();
-    return this.habitatCommentService.resolveComment(commentId, req.user.id);
+    return this.habitatCommentService.resolveComment(commentId, req.user.sub);
   }
 
   /**


### PR DESCRIPTION
…with authentication practices

- Changed the user ID reference from req.user.id to req.user.sub in the habitat comment controller.
- This update ensures consistency in user identification across the habitat comment resolution process, following updated authentication standards.