### PR TITLE
refactor: remove unused dependencies and enhance role-based access in…

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
@@ -43,6 +43,7 @@ export class HabitatCommentController {
    * Crée un nouveau commentaire d'habitat
    */
   @Post()
+  @Roles('admin', 'veterinary')
   async createHabitatComment(
     @Body() habitatCommentData: HabitatComment,
     @Request() req,

--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/habitat-comment.module.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/habitat-comment.module.ts
@@ -1,7 +1,5 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
-import { AccountModule } from '../../admin-dashboard/account-management/account.module';
-import { HabitatModule } from '../../admin-dashboard/habitat-management/habitat.module';
 import { HabitatCommentController } from './controllers/habitat-comment.controller';
 import { HabitatCommentSchema } from './schemas/habitat-comment.schema';
 import { HabitatCommentService } from './services/habitat-comment.service';
@@ -15,8 +13,6 @@ import { HabitatCommentService } from './services/habitat-comment.service';
         collection: 'habitat_comments',
       },
     ]),
-    AccountModule,
-    HabitatModule,
   ],
   controllers: [HabitatCommentController],
   providers: [HabitatCommentService],

--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { AccountService } from 'src/modules/dashboard/admin-dashboard/account-management/services/account.service';
-import { HabitatService } from 'src/modules/dashboard/admin-dashboard/habitat-management/services/habitat.service';
 import { HabitatComment } from '../models/habitat-comment.model';
 
 @Injectable()
@@ -10,8 +8,6 @@ export class HabitatCommentService {
   constructor(
     @InjectModel('HabitatComment')
     private readonly habitatCommentModel: Model<HabitatComment>,
-    private readonly accountService: AccountService,
-    private readonly habitatService: HabitatService,
   ) {}
 
   /**
@@ -65,23 +61,10 @@ export class HabitatCommentService {
   ): Promise<HabitatComment> {
     console.log('Données reçues:', habitatCommentData);
 
-    const user = await this.accountService.findOne(userId);
-    const habitat = await this.habitatService.findOne(
-      habitatCommentData.id_habitat,
-    );
-
-    if (!habitat) {
-      throw new NotFoundException(
-        `Habitat avec l'ID ${habitatCommentData.id_habitat} non trouvé`,
-      );
-    }
-
     const newHabitatComment = new this.habitatCommentModel({
       ...habitatCommentData,
       id_habitat: Number(habitatCommentData.id_habitat),
-      habitat_name: habitat.name,
       id_user: userId,
-      user_name: user.name,
       createdAt: new Date(),
       updatedAt: new Date(),
     });


### PR DESCRIPTION
… habitat comment module

- Removed AccountModule and HabitatModule imports from habitat-comment.module.ts to streamline dependencies.
- Added role-based access control to the createHabitatComment method in habitat-comment.controller.ts, allowing only 'admin' and 'veterinary' roles to create habitat comments.
- Cleaned up habitat-comment.service.ts by eliminating unused services, improving code clarity and maintainability.