### PR TITLE
feat: add is_resolved field to habitat comment creation

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -70,6 +70,7 @@ export class HabitatCommentService {
       habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
       createdAt: new Date(),
       updatedAt: new Date(),
+      is_resolved: false,
     });
 
     console.log('Nouveau commentaire à sauvegarder:', newHabitatComment);


### PR DESCRIPTION
- Introduced the is_resolved field in the habitat comment creation process, defaulting to false.
- This enhancement allows for better tracking of comment resolution status, improving the overall functionality of the habitat comment feature.