### PR TITLE
feat: enhance habitat comment schema and service with required fields…

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/schemas/habitat-comment.schema.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/schemas/habitat-comment.schema.ts
@@ -3,10 +3,10 @@ import { Schema } from 'mongoose';
 export const HabitatCommentSchema = new Schema(
   {
     id_habitat_comment: { type: String },
-    id_habitat: { type: Number, required: true, index: true },
-    habitat_name: { type: String },
+    id_habitat: { type: Number, required: true },
+    habitat_name: { type: String, required: true },
     id_user: { type: Number, required: true },
-    user_name: { type: String },
+    user_name: { type: String, required: true },
     comment: { type: String, required: true },
     habitat_status: {
       type: String,
@@ -16,6 +16,8 @@ export const HabitatCommentSchema = new Schema(
     is_resolved: { type: Boolean, default: false },
     resolved_at: { type: Date },
     resolved_by: { type: String },
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: Date.now },
   },
   {
     timestamps: true,

--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -63,13 +63,12 @@ export class HabitatCommentService {
     console.log('Données reçues:', habitatCommentData);
 
     const newHabitatComment = new this.habitatCommentModel({
-      ...habitatCommentData,
       id_habitat: Number(habitatCommentData.id_habitat),
+      habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
       id_user: userId,
       user_name: username,
-      habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      comment: habitatCommentData.comment,
+      habitat_status: habitatCommentData.habitat_status,
       is_resolved: false,
     });
 


### PR DESCRIPTION
… and timestamps

- Updated the HabitatCommentSchema to make habitat_name and user_name required fields, ensuring that all comments are associated with a user and habitat.
- Added createdAt and updatedAt fields to the schema for better tracking of comment creation and modification times.
- Modified the habitat comment service to streamline the creation process by directly assigning the habitat_name based on id_habitat, improving data consistency and clarity.