### PR TITLE
feat: enforce required userId and username in habitat comment creation

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -62,6 +62,11 @@ export class HabitatCommentService {
   ): Promise<HabitatComment> {
     console.log('Données reçues:', habitatCommentData);
 
+    // Vérification des données requises
+    if (!userId || !username) {
+      throw new Error('userId et username sont requis');
+    }
+
     const newHabitatComment = new this.habitatCommentModel({
       id_habitat: Number(habitatCommentData.id_habitat),
       habitat_name: `Habitat ${habitatCommentData.id_habitat}`,


### PR DESCRIPTION
- Added validation to the createHabitatComment method to ensure userId and username are provided, enhancing data integrity and preventing incomplete submissions.
- This change improves the reliability of habitat comments by ensuring that all comments are associated with a valid user.