### PR TITLE
refactor: streamline habitat comment creation by removing user ID and…

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -62,18 +62,10 @@ export class HabitatCommentService {
   ): Promise<HabitatComment> {
     console.log('Données reçues:', habitatCommentData);
 
-    // Vérification des données requises
-    if (!userId || !username) {
-      throw new Error('userId et username sont requis');
-    }
-
     const newHabitatComment = new this.habitatCommentModel({
+      ...habitatCommentData,
       id_habitat: Number(habitatCommentData.id_habitat),
       habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
-      id_user: userId,
-      user_name: username,
-      comment: habitatCommentData.comment,
-      habitat_status: habitatCommentData.habitat_status,
       is_resolved: false,
     });
 


### PR DESCRIPTION
… username validation

- Simplified the createHabitatComment method in the HabitatCommentService by removing the requirement for userId and username, allowing for more flexible comment submissions.
- The habitat_name is now directly assigned based on id_habitat, improving data consistency.
- This change enhances the usability of the habitat comment feature by accommodating scenarios where user information may not be available.