### PR TITLE
feat: enhance habitat comment creation with structured data and times…

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -62,7 +62,17 @@ export class HabitatCommentService {
   ): Promise<HabitatComment> {
     console.log('Données reçues:', habitatCommentData);
 
-    const newHabitatComment = new this.habitatCommentModel(habitatCommentData);
+    const newHabitatComment = new this.habitatCommentModel({
+      ...habitatCommentData,
+      id_habitat: Number(habitatCommentData.id_habitat),
+      id_user: userId,
+      user_name: username,
+      habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
+      is_resolved: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
     console.log('Nouveau commentaire à sauvegarder:', newHabitatComment);
     return await newHabitatComment.save();
   }


### PR DESCRIPTION
…tamps

- Updated the createHabitatComment method in HabitatCommentService to include user ID, username, habitat name, and timestamps (createdAt, updatedAt) in the habitat comment data structure.
- The id_habitat is now explicitly converted to a number, ensuring data consistency.
- Introduced a default value for is_resolved, set to false, to track comment resolution status effectively.
- These changes improve data integrity and provide better context for habitat comments, aligning with previous enhancements to the habitat comment feature.