### PR TITLE
feat: update habitat comment creation to use user ID and name, and in…

### DIFF
--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/controllers/habitat-comment.controller.ts
@@ -53,8 +53,9 @@ export class HabitatCommentController {
 
     const commentData = {
       ...habitatCommentData,
-      id_user: req.user.sub,
-      user_name: req.user.username,
+      id_user: req.user.id,
+      user_name: req.user.name,
+      habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
       is_resolved: false,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -63,8 +64,8 @@ export class HabitatCommentController {
     console.log('Données à envoyer au service:', commentData);
     return this.habitatCommentService.createHabitatComment(
       commentData,
-      req.user.sub,
-      req.user.username,
+      req.user.id,
+      req.user.name,
     );
   }
 

--- a/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
+++ b/src/modules/dashboard/veterinary-dashboard/habitat-comment/services/habitat-comment.service.ts
@@ -62,7 +62,17 @@ export class HabitatCommentService {
   ): Promise<HabitatComment> {
     console.log('Données reçues dans le service:', habitatCommentData);
 
-    const newHabitatComment = new this.habitatCommentModel(habitatCommentData);
+    const newHabitatComment = new this.habitatCommentModel({
+      ...habitatCommentData,
+      id_habitat: Number(habitatCommentData.id_habitat),
+      id_user: userId,
+      user_name: username,
+      habitat_name: `Habitat ${habitatCommentData.id_habitat}`,
+      is_resolved: false,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
     console.log('Nouveau commentaire à sauvegarder:', newHabitatComment);
     return await newHabitatComment.save();
   }


### PR DESCRIPTION
…clude habitat name

- Refactored the HabitatCommentController and HabitatCommentService to utilize req.user.id and req.user.name instead of req.user.sub and req.user.username for improved clarity and consistency.
- Added habitat_name to the comment data structure, enhancing context for each comment.
- Ensured that createdAt and updatedAt timestamps are included in the habitat comment data, maintaining comprehensive tracking of comment creation and updates.
- These changes improve data integrity and usability of the habitat comment feature, aligning with previous enhancements.